### PR TITLE
Replace np.complex with complex

### DIFF
--- a/latest/spirograph.py
+++ b/latest/spirograph.py
@@ -204,7 +204,7 @@ class Spirograph(inkBase.inkscapeMadeEasy):
 
     # typeCurve: 'hypo', 'epi'
     def calcCurve__trochoid(self, typeCurve, R, r, d, thetas):
-        j = np.complex(0, 1)
+        j = complex(0, 1)
         if typeCurve.lower() == 'hypo':
             # https://www.mathcurve.com/courbes2d.gb/hypotrochoid/hypotrochoid.shtml
             P_complex = (R - r) * np.exp(j * thetas) + d * np.exp(-j * thetas * (R - r) / r)


### PR DESCRIPTION
module 'numpy' has no attribute 'complex'. `np.complex` was a deprecated alias for the builtin `complex`.

Fixes #1